### PR TITLE
Результирующий вывод.

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -63,19 +63,64 @@ var samples = [
 	{ name : 'ECT', sample : ect }
 ];
 
+var results = [];
+
+function showResultsPersent(label, prop) {
+	var i, l, per, minVal, arr = results.slice();
+	
+	function log(name, val, per) {
+		console.log('  ' + name + ': ' + val + 'ms - ' + per.toFixed(2) + '%');
+	}
+	
+	arr.sort(function (a, b) { return a[prop] - b[prop]; });
+	
+	minVal = arr[0][prop];
+	console.log(label);
+	
+	log(arr[0].name, minVal, 100);
+	
+	for (i = 1, l = arr.length; l > i; i += 1) {
+		if (minVal) {
+			per = (arr[i][prop] / minVal) * 100;
+		} else {
+			per = arr[i][prop] * 100;
+		}
+		
+		log(arr[i].name, arr[i][prop], per);
+	}
+	
+	console.log('');
+}
+
 var runTests = function () {
 	if (samples.length) {
 		var sample = samples.pop();
 		test(sample.name, sample.sample, function (err, name, result) {
 			testUnescaped(sample.name, sample.sample, function (err, name, resultUnescaped) {
+				var total = result + resultUnescaped,
+					s = {
+							name: name,
+							escaped: result,
+							unescaped: resultUnescaped,
+							total: total
+					};
+					
 				console.log(name);
 				console.log('  Escaped   : ' + result + 'ms');
 				console.log('  Unescaped : ' + resultUnescaped + 'ms');
-				console.log('  Total     : ' + (result + resultUnescaped) + 'ms');
+				console.log('  Total     : ' + total + 'ms');
 				console.log('');
+				
+				
+				results.push(s);
+				
 				runTests();
 			});
 		});
+	} else {
+		console.log('--------------');
+		showResultsPersent('Compare escaped', 'escaped');
+		showResultsPersent('Compare unescaped', 'unescaped');
 	}
 };
 


### PR DESCRIPTION
После всех тестов показываем сравнение результатов тестирования.

Compare escaped

```
ECT: 13793ms - 100.00%
Dust: 14257ms - 103.36%
Fest: 15128ms - 109.68%
Handlebars.js: 16460ms - 119.34%
doT: 17233ms - 124.94%
Hogan.js: 17992ms - 130.44%
Swig: 18408ms - 133.46%
Jade without `with`: 26176ms - 189.78%
EJS: 29035ms - 210.51%
Eco: 33273ms - 241.23%
Jade: 46867ms - 339.79%
```
