### PR TITLE
Swig tuning, autoescape: false

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -14,6 +14,7 @@ var fest = require('./fest/fest.js');
 var dot = require('./dot/dot.js');
 var handlebars = require('./handlebars/handlebars.js');
 var coffeekup = require('./coffeekup/coffeekup.js');
+var underscore = require('./underscore/underscore.js');
 
 var test = function(name, sample, cb) {
 	var i = 0;
@@ -64,7 +65,8 @@ var samples = [
 	{ name : 'Fest', sample : fest },
 	{ name : 'Hogan.js', sample : hogan },
 	{ name : 'Dust', sample : dust },
-	{ name : 'ECT', sample : ect }
+	{ name : 'ECT', sample : ect },
+    { name : 'Underscore', sample : underscore }
 ];
 
 var runTests = function () {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"fest": "0.4.4",
 		"dot": "0.2.6",
 		"handlebars": "1.0.7",
-		"coffeekup": "0.3.1"
+		"coffeekup": "0.3.1",
+        "underscore": "1.4.3"
 	}
 }

--- a/swig/swig.js
+++ b/swig/swig.js
@@ -3,7 +3,9 @@ var compiled;
 var tplData;
 
 swig.init({
-	root: __dirname
+	root: __dirname,
+    autoescape: false,
+    cache: true
 });
 
 module.exports.prepare = function (data, done) {

--- a/swig/tpl_escaped.swig
+++ b/swig/tpl_escaped.swig
@@ -1,13 +1,13 @@
 <html>
 	<head>
-		<title>{{ title }}</title>
+		<title>{{ title|e }}</title>
 	</head>
 	<body>
-		<p>{{ text }}</p>
+		<p>{{ text|e }}</p>
 		{% if projects.length %}
 			{% for project in projects %}
-				<a href="{{ project.url }}">{{ project.name }}</a>
-				<p>{{ project.description }}</p>
+				<a href="{{ project.url|e }}">{{ project.name|e }}</a>
+				<p>{{ project.description|e }}</p>
 			{% endfor %}
 		{% else %}
 			No projects

--- a/swig/tpl_unescaped.swig
+++ b/swig/tpl_unescaped.swig
@@ -1,13 +1,13 @@
 <html>
 	<head>
-		<title>{{ title|raw }}</title>
+		<title>{{ title }}</title>
 	</head>
 	<body>
-		<p>{{ text|raw }}</p>
+		<p>{{ text }}</p>
 		{% if projects.length %}
 			{% for project in projects %}
-				<a href="{{ project.url|raw }}">{{ project.name|raw }}</a>
-				<p>{{ project.description|raw }}</p>
+				<a href="{{ project.url }}">{{ project.name }}</a>
+				<p>{{ project.description }}</p>
 			{% endfor %}
 		{% else %}
 			No projects

--- a/underscore/tpl_escaped.html
+++ b/underscore/tpl_escaped.html
@@ -5,10 +5,10 @@
 <body>
 <p><%- text %></p>
 <% if(projects.length) { %>
-    <% for (project in projects) { %>
+    <% _.each(projects, function(project) { %>
         <a href="<%- project.url %>"><%- project.name %></a>
         <p><%- project.description %></p>
-    <% } %>
+    <% }); %>
 <% } else { %>
 No projects
 <% } %>

--- a/underscore/tpl_escaped.html
+++ b/underscore/tpl_escaped.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+    <title><%- title %></title>
+</head>
+<body>
+<p><%- text %></p>
+<% if(projects.length) { %>
+    <% for (project in projects) { %>
+        <a href="<%- project.url %>"><%- project.name %></a>
+        <p><%- project.description %></p>
+    <% } %>
+<% } else { %>
+No projects
+<% } %>
+</body>
+</html>

--- a/underscore/tpl_unescaped.html
+++ b/underscore/tpl_unescaped.html
@@ -5,12 +5,12 @@
 <body>
 <p><%= text %></p>
 <% if(projects.length) { %>
-<% for (project in projects) { %>
-<a href="<%= project.url %>"><%= project.name %></a>
-<p><%= project.description %></p>
-<% } %>
+    <% _.each(projects, function(project) { %>
+        <a href="<%= project.url %>"><%= project.name %></a>
+        <p><%= project.description %></p>
+    <% }) %>
 <% } else { %>
-No projects
+    No projects
 <% } %>
 </body>
 </html>

--- a/underscore/tpl_unescaped.html
+++ b/underscore/tpl_unescaped.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+    <title><%= title %></title>
+</head>
+<body>
+<p><%= text %></p>
+<% if(projects.length) { %>
+<% for (project in projects) { %>
+<a href="<%= project.url %>"><%= project.name %></a>
+<p><%= project.description %></p>
+<% } %>
+<% } else { %>
+No projects
+<% } %>
+</body>
+</html>

--- a/underscore/underscore.js
+++ b/underscore/underscore.js
@@ -1,0 +1,23 @@
+var fs = require('fs');
+var _ = require('underscore');
+var compiled;
+var tplData;
+
+module.exports.prepare = function (data, done) {
+    var str = fs.readFileSync(__dirname + '/tpl_escaped.html', 'utf8');
+    tplData = data;
+    compiled = _.template(str);
+    done();
+};
+
+module.exports.prepareUnescaped = function (data, done) {
+    var str = fs.readFileSync(__dirname + '/tpl_unescaped.html', 'utf8');
+    tplData = data;
+    compiled = _.template(str);
+    done();
+};
+
+module.exports.step = function (done) {
+    var html = compiled(tplData);
+    done(undefined, html);
+};


### PR DESCRIPTION
Swig has a strange behaviour with autoescape. it is highly recommended to leave this on in production but when it switched off and escaping forced via the escape filter swig has an incredible results.

ECT
  Escaped   : 1579ms
  Unescaped : 78ms
  Total     : 1657ms

Dust
  Escaped   : 1831ms
  Unescaped : 250ms
  Total     : 2081ms

Hogan.js
  Escaped   : 2128ms
  Unescaped : 510ms
  Total     : 2638ms

Fest
  Escaped   : 2914ms
  Unescaped : 160ms
  Total     : 3074ms

Handlebars.js
  Escaped   : 2999ms
  Unescaped : 176ms
  Total     : 3175ms

EJS without `with`
  Escaped   : 3333ms
  Unescaped : 269ms
  Total     : 3602ms

doT
  Escaped   : 3553ms
  Unescaped : 45ms
  Total     : 3598ms

Swig
  Escaped   : 259ms
  Unescaped : 260ms
  Total     : 519ms

Eco
  Escaped   : 5784ms
  Unescaped : 487ms
  Total     : 6271ms

EJS
  Escaped   : 4353ms
  Unescaped : 1848ms
  Total     : 6201ms

Jade without `with`
  Escaped   : 5883ms
  Unescaped : 2110ms
  Total     : 7993ms

CoffeeKup
  Escaped   : 2774ms
  Unescaped : 5990ms
  Total     : 8764ms

Jade
  Escaped   : 10747ms
  Unescaped : 7282ms
  Total     : 18029ms
